### PR TITLE
develop

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,29 +18,6 @@ jobs:
       run: cargo build --verbose
     - name: Tests
       run: cargo test --verbose
-  
-  build-windows:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Tests
-      run: cargo test --verbose
-  
-  build-mac:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Tests
-      run: cargo test --verbose
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
     - name: Coverage
       run: |
         cargo install cargo-tarpaulin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,47 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Tests
+      run: cargo test --verbose
+  
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Tests
+      run: cargo test --verbose
+  
+  build-mac:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Tests
+      run: cargo test --verbose
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Coverage
+      run: |
+        cargo install cargo-tarpaulin
+        cargo tarpaulin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![mirror](https://img.shields.io/badge/mirror-gitlab-orange)](https://gitlab.com/cocainefarm/julianday)
 [![mirror](https://img.shields.io/badge/mirror-github-blue)](https://github.com/cocainefarm/julianday)
 [![crates.io](https://img.shields.io/crates/v/julianday.svg)](https://crates.io/crates/julianday)
+[![Rust](https://github.com/cocainefarm/julianday/actions/workflows/rust.yml/badge.svg)](https://github.com/cocainefarm/julianday/actions/workflows/rust.yml)
 [![docs.rs](https://docs.rs/julianday/badge.svg)](https://docs.rs/julianday)
 
 Julian day is the continuous count of days since the beginning of the Julian Period.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,9 @@
 //!  fn main() {
 //!     let date = NaiveDate::from_ymd(1858, 11, 17);
 //!     let mjd = ModifiedJulianDay::from(date);
-//!     let jd = JulianDay::new(2400001);
 //!     assert_eq!(mjd, ModifiedJulianDay::new(0));
+//!     let jd : JulianDay = mjd.into();
+//!     assert_eq!(jd, JulianDay::new(2400001));
 //!  }
 //!  ```
 
@@ -50,6 +51,18 @@ impl From<NaiveDate> for JulianDay {
         let jd = day + (153 * m + 2) / 5 + y * 365 + y / 4 - y / 100 + y / 400 - 32045;
 
         JulianDay(jd as i32)
+    }
+}
+
+impl Into<i32> for JulianDay {
+    fn into (self) -> i32 {
+        self.inner()
+    }
+}
+
+impl Into<ModifiedJulianDay> for JulianDay {
+    fn into (self) -> ModifiedJulianDay {
+        ModifiedJulianDay(self.inner() - 2400001)
     }
 }
 
@@ -93,6 +106,18 @@ impl From<NaiveDate> for ModifiedJulianDay {
     fn from (date: NaiveDate) -> Self {
         let jd : JulianDay = date.into();
         ModifiedJulianDay(jd.inner() - 2400001)
+    }
+}
+
+impl Into<i32> for ModifiedJulianDay {
+    fn into (self) -> i32 {
+        self.inner()
+    }
+}
+
+impl Into<JulianDay> for ModifiedJulianDay {
+    fn into (self) -> JulianDay {
+        JulianDay(self.inner() + 2400001)
     }
 }
 
@@ -160,5 +185,21 @@ mod tests {
         let date = NaiveDate::from_ymd(1858, 11, 16);
         let mjd = ModifiedJulianDay::from(date);
         assert_eq!(mjd, ModifiedJulianDay(-1));
+    }
+
+    #[test]
+    fn test_casts() {
+        let jd = JulianDay(2458898);
+        let days :i32 = jd.into();
+        assert_eq!(days, 2458898);
+        let mjd = ModifiedJulianDay(58897);
+        let days :i32 = mjd.into(); 
+        assert_eq!(days, 58897);
+        let mjd = ModifiedJulianDay(1);
+        let jd : JulianDay = mjd.into();
+        assert_eq!(jd, JulianDay::new(2400002));
+        let jd = JulianDay(2400010);
+        let mjd : ModifiedJulianDay = jd.into();
+        assert_eq!(mjd, ModifiedJulianDay::new(9));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,21 @@
 //!     let date = julianday.to_date();
 //! }
 //! ```
+//!  
+//!  Modified Julian Days are translated Julian Days, starting on November 17 1858 at midnight
+//!
+//!  # Example
+//!  ```
+//!  use chrono::NaiveDate;
+//!  use julianday::{JulianDay, ModifiedJulianDay};
+//!  
+//!  fn main() {
+//!     let date = NaiveDate::from_ymd(1858, 11, 17);
+//!     let mjd = ModifiedJulianDay::from(date);
+//!     let jd = JulianDay::new(2400001);
+//!     assert_eq!(mjd, ModifiedJulianDay::new(0));
+//!  }
+//!  ```
 
 use chrono::{self, Datelike, NaiveDate};
 use std::convert::From;
@@ -77,8 +92,7 @@ impl From<NaiveDate> for ModifiedJulianDay {
     /// Get a ModifiedJulianDay from a NaiveDate
     fn from (date: NaiveDate) -> Self {
         let jd : JulianDay = date.into();
-        let mjd = (jd.inner() as f32 - 2400000.5).round();
-        ModifiedJulianDay(mjd as i32)
+        ModifiedJulianDay(jd.inner() - 2400001)
     }
 }
 
@@ -93,8 +107,7 @@ impl ModifiedJulianDay {
     }
 
     pub fn to_date (self) -> NaiveDate {
-        let jd = (self.inner() as f32 + 2400000.5).round();
-        let jd = JulianDay(jd as i32);
+        let jd = JulianDay(self.inner() + 2400001); 
         jd.to_date()
     }
 }
@@ -124,16 +137,28 @@ mod tests {
 
     #[test]
     fn mjd_to_naivedate() {
-        let mjd = ModifiedJulianDay::new(57000);
-        let naivedate = NaiveDate::from_ymd(2014, 12, 9);
+        let mjd = ModifiedJulianDay::new(58897);
+        let naivedate = NaiveDate::from_ymd(2020, 2, 18);
         let date = mjd.to_date();
         assert_eq!(date, naivedate);
+        let mjd = ModifiedJulianDay::new(57005);
+        let naivedate = NaiveDate::from_ymd(2014, 12, 14);
+        assert_eq!(mjd.to_date(), naivedate);
     }
 
     #[test]
     fn naivedate_to_mjd() {
-        let mjd = ModifiedJulianDay::new(57000);
-        let naivedate = NaiveDate::from_ymd(2014, 12, 9);
-        assert_eq!(mjd.to_date(), naivedate);
+        let date = NaiveDate::from_ymd(2014, 12, 14);
+        let mjd = ModifiedJulianDay::from(date);
+        assert_eq!(mjd, ModifiedJulianDay(57005));
+        let date = NaiveDate::from_ymd(1858, 11, 17);
+        let mjd = ModifiedJulianDay::from(date);
+        assert_eq!(mjd, ModifiedJulianDay(0));
+        let date = NaiveDate::from_ymd(1858, 11, 18);
+        let mjd = ModifiedJulianDay::from(date);
+        assert_eq!(mjd, ModifiedJulianDay(1));
+        let date = NaiveDate::from_ymd(1858, 11, 16);
+        let mjd = ModifiedJulianDay::from(date);
+        assert_eq!(mjd, ModifiedJulianDay(-1));
     }
 }


### PR DESCRIPTION
Hello @maxaudron,

with these contributions:

* I fix a 1/2 day rounding issue when casting MJD to naive dates (midday->midnight)
* added a paragraph in the doc for MJD/JD and cast examples, also little explanation on MJDs

* introduce a github workflow. Will be triggered by any github->master activity, not on gitlab.
You should see the resulting badge appear in the README, even in the gitlab mirror

* coverage results can be seen at the end of `Coverage` step. It is only visible in that console at the moment.
For information, coverage is **100%** even with these new contributions.
If you are interested in having a coverage badge, unfortunately this is not enough. If you are interested but don't know how to do it, we can discuss available options later on

* I added convenient JD->i32 MJD->i32 and JD<->MJD cast methods